### PR TITLE
Vagrant config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ migrations
 migrations/
 db.*
 settings_local.py
+.vagrant/

--- a/.vagrantplugins
+++ b/.vagrantplugins
@@ -1,0 +1,33 @@
+class DjangoStart < Vagrant.plugin(2, :command)
+  def self.synopsis
+    "Says Hello"
+  end
+
+  def execute
+    puts "Hello"
+    0
+  end
+end
+
+class DjangoStop < Vagrant.plugin(2, :command)
+  def self.synopsis
+    "Says Goodbye"
+  end
+
+  def execute
+    puts "Goodbye"
+    0
+  end
+end
+
+class DjangoControl < Vagrant.plugin(2)
+  name "Django Control"
+
+  command "server-start" do
+    DjangoStart
+  end
+
+  command "server-stop" do
+    DjangoStop
+  end
+end

--- a/ACM_General/ACM_General/settings.py
+++ b/ACM_General/ACM_General/settings.py
@@ -22,8 +22,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = [u'162.243.186.23',
-                 u'kevinschoonover.me',]
+ALLOWED_HOSTS = [u'localhost']
 
 ENFORCED_EMAIL_DOMAINS = ['mst.edu']
 
@@ -135,4 +134,4 @@ STATIC_URL = '/static/'
 
 
 # Temporary local settings
-from settings_local.py import *
+from .settings_local import *

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,71 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "base"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,60 +12,47 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "base"
-
-  # Disable automatic box update checking. If you disable this, then
-  # boxes will only be checked for updates when the user runs
-  # `vagrant box outdated`. This is not recommended.
-  # config.vm.box_check_update = false
+  config.vm.box = "debian/jessie64"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
-  # config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.network "forwarded_port", guest: 8000, host: 8000
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
   # config.vm.network "private_network", ip: "192.168.33.10"
 
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
-
   # Share an additional folder to the guest VM. The first argument is
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
-
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
-  # Example for VirtualBox:
-  #
-  # config.vm.provider "virtualbox" do |vb|
-  #   # Display the VirtualBox GUI when booting the machine
-  #   vb.gui = true
-  #
-  #   # Customize the amount of memory on the VM:
-  #   vb.memory = "1024"
-  # end
-  #
-  # View the documentation for the provider you are using for more
-  # information on available options.
-
-  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
-  # such as FTP and Heroku are also available. See the documentation at
-  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
-  # config.push.define "atlas" do |push|
-  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
-  # end
+  # config.vm.synced_folder "../acm.mst.edu", "/www/acm.mst.edu"
 
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
-  # config.vm.provision "shell", inline: <<-SHELL
-  #   apt-get update
-  #   apt-get install -y apache2
-  # SHELL
+  $updates = <<-SHELL
+    apt-get update
+    apt-get install -y python3 python3-pip postgresql libpq-dev
+  SHELL
+
+  $db = <<-DB
+    sudo -u postgres psql -c "create database django_acmgeneral" \
+         -c "create user djangouser with password 'djangoUserPassword'" \
+         -c "grant all privileges on database django_acmgeneral to djangouser"
+  DB
+
+  $migrate = <<-MIGRATE
+    cd /vagrant 
+    pip3 install -r requirements.txt
+    cd ACM_General/
+    cp ACM_General/settings_local.template ACM_General/settings_local.py
+    python3 manage.py makemigrations
+    python3 manage.py migrate
+  MIGRATE
+
+  config.vm.provision :shell, inline: $updates
+  config.vm.provision :shell, inline: $db
+  config.vm.provision :shell, inline: $migrate
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,7 +48,7 @@ Vagrant.configure("2") do |config|
     pip3 install -r requirements.txt
     cd ACM_General/
     cp ACM_General/settings_local.template ACM_General/settings_local.py
-    python3 manage.py makemigrations
+    python3 manage.py makemigrations accounts core events home sigs thirdparty_auth
     python3 manage.py migrate
   MIGRATE
 


### PR DESCRIPTION
Vagrant commands should probably be added at some point for better host control over the vm (from the command line). Ideally it will be stuff like `vagrant server-start`, `vagrant server-stop`, etc. At the moment it is still necessary to `vagrant ssh` into the box and start the dev web server manually.

Oh and I will overhaul the documentation for the README once this is finalized.