### PR TITLE
Vagrant config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,22 +12,17 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "debian/jessie64"
-
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
-  config.vm.network "forwarded_port", guest: 8000, host: 8000
-
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  config.vm.network "private_network", type: "dhcp"
+  config.vm.box = "ubuntu/trusty64"
 
   # Share an additional folder to the guest VM. The first argument is
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
   config.vm.synced_folder ".", "/vagrant", type: "nfs"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network "private_network", type: "dhcp"
 
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
@@ -38,13 +33,13 @@ Vagrant.configure("2") do |config|
   SHELL
 
   $db = <<-DB
-    sudo -u postgres psql -c "create database django_acmgeneral" \
-         -c "create user djangouser with password 'djangoUserPassword'" \
-         -c "grant all privileges on database django_acmgeneral to djangouser"
+    sudo -u postgres psql -c "create database django_acmgeneral;" \
+         -c "create user djangouser with password 'djangoUserPassword';" \
+         -c "grant all privileges on database django_acmgeneral to djangouser;"
   DB
 
   $migrate = <<-MIGRATE
-    cd /vagrant 
+    cd /vagrant
     pip3 install -r requirements.txt
     cd ACM_General/
     cp ACM_General/settings_local.template ACM_General/settings_local.py

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,20 +22,21 @@ Vagrant.configure("2") do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
+  config.vm.network "forwarded_port", guest: 8000, host: 8000
   config.vm.network "private_network", type: "dhcp"
 
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
-  $updates = <<-SHELL
+  $updates = <<-UPDATE
     apt-get update
-    apt-get install -y python3 python3-pip postgresql libpq-dev nfs-kernel-server nfs-common
-  SHELL
+    apt-get install -y python3 python3-pip postgresql libpq-dev nfs-common
+  UPDATE
 
   $db = <<-DB
-    sudo -u postgres psql -c "create database django_acmgeneral;" \
-         -c "create user djangouser with password 'djangoUserPassword';" \
-         -c "grant all privileges on database django_acmgeneral to djangouser;"
+    sudo -u postgres psql -c "create database django_acmgeneral"
+    sudo -u postgres psql -c "create user djangouser with password 'djangoUserPassword'"
+    sudo -u postgres psql -c "grant all privileges on database django_acmgeneral to djangouser"
   DB
 
   $migrate = <<-MIGRATE
@@ -45,9 +46,17 @@ Vagrant.configure("2") do |config|
     cp ACM_General/settings_local.template ACM_General/settings_local.py
     python3 manage.py makemigrations accounts core events home sigs thirdparty_auth
     python3 manage.py migrate
+
   MIGRATE
+
+  $setup = <<-SETUP
+    tmux new-session -d -s django 'cd /vagrant/ACM_General && python3 manage.py runserver 0.0.0.0:8000'
+    tmux ls
+    tmux detach -s django
+  SETUP
 
   config.vm.provision :shell, inline: $updates
   config.vm.provision :shell, inline: $db
   config.vm.provision :shell, inline: $migrate
+  config.vm.provision :shell, inline: $setup
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure("2") do |config|
   # documentation for more information about their specific syntax and use.
   $updates = <<-SHELL
     apt-get update
-    apt-get install -y python3 python3-pip postgresql libpq-dev
+    apt-get install -y python3 python3-pip postgresql libpq-dev nfs-kernel-server nfs-common
   SHELL
 
   $db = <<-DB

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,7 +46,6 @@ Vagrant.configure("2") do |config|
     cp ACM_General/settings_local.template ACM_General/settings_local.py
     python3 manage.py makemigrations accounts core events home sigs thirdparty_auth
     python3 manage.py migrate
-
   MIGRATE
 
   $setup = <<-SETUP

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,13 +21,13 @@ Vagrant.configure("2") do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
+  config.vm.network "private_network", type: "dhcp"
 
   # Share an additional folder to the guest VM. The first argument is
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  # config.vm.synced_folder "../acm.mst.edu", "/www/acm.mst.edu"
+  config.vm.synced_folder ".", "/vagrant", type: "nfs"
 
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the


### PR DESCRIPTION
Should now work on MS Windows hosts. NFS shared folders will be used when NFS is available on the host, otherwise virtualbox shared folders will be used. Also the webserver is started when the vm is provisioned and uses tmux to persist in the vm. To check the status of the webserver it is necessary to connect via ssh and attach the tmux session named `django`. This is accomplished with the command `tmux a -s django`.