### PR TITLE
Fixed referencing issue

### DIFF
--- a/ACM_General/events/templates/events/listEvents.html
+++ b/ACM_General/events/templates/events/listEvents.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "core/base.html" %}
 
 {% block body_main %}
     <p> Current Time is {{ currentTime }} </p>


### PR DESCRIPTION
-Made changes to the listEvents.html file under the Events app
-Changed the extend tag to 'core/base' instead of just core
-Page can now be opened via browser without error